### PR TITLE
Handle missing session key

### DIFF
--- a/src/services/n8nBlueprintWebhookService.ts
+++ b/src/services/n8nBlueprintWebhookService.ts
@@ -81,8 +81,14 @@ export class N8nBlueprintWebhookService {
 
       try {
         console.log('📤 ENVOI MULTIPART/FORM-DATA VERS N8N...');
+        
+        // Ajout clé de session en tant que champ et en query param
+        const { WebhookUrlHelper } = await import('../utils/webhookUrlHelper');
+        const key = WebhookUrlHelper.getSessionKey();
+        formData.set('key', key);
+        const urlWithKey = WebhookUrlHelper.appendQueryParams(this.WEBHOOK_URL, { key });
 
-        const response = await fetch(this.WEBHOOK_URL, {
+        const response = await fetch(urlWithKey, {
           method: 'POST',
           // ⚠️ PAS de Content-Type header - laissé au navigateur pour multipart/form-data
           headers: {

--- a/src/services/n8nWebhookService.ts
+++ b/src/services/n8nWebhookService.ts
@@ -10,9 +10,11 @@ interface ProductWithDeliveryStatus {
 // 🚀 SERVICE D'ENVOI VERS N8N AVEC VALIDATION
 export class N8nWebhookService {
   private static get WEBHOOK_URL() {
-    const url = WebhookUrlHelper.getWebhookUrl('webhook/facture-universelle');
-    console.log('🔗 N8nWebhookService - Using webhook URL:', url);
-    return url;
+    const base = WebhookUrlHelper.getWebhookUrl('webhook/facture-universelle');
+    const key = WebhookUrlHelper.getSessionKey();
+    const urlWithKey = WebhookUrlHelper.appendQueryParams(base, { key });
+    console.log('🔗 N8nWebhookService - Using webhook URL:', urlWithKey);
+    return urlWithKey;
   }
   private static readonly TIMEOUT_MS = 30000; // 30 secondes
 
@@ -50,6 +52,8 @@ export class N8nWebhookService {
 
       // 2. 📦 STRUCTURE DU PAYLOAD IDENTIQUE AU COMMIT FONCTIONNEL e54c7f9
       const webhookPayload = {
+        // ✅ Session key pour N8N Chat session/Key param
+        key: WebhookUrlHelper.getSessionKey(),
         // PDF data
         nom_facture: `Facture_MYCONFORT_${invoice.invoiceNumber}`,
         fichier_facture: pdfBase64, // Base64 du PDF

--- a/src/utils/webhookUrlHelper.ts
+++ b/src/utils/webhookUrlHelper.ts
@@ -110,7 +110,7 @@ export class WebhookUrlHelper {
    * Vérifie si on est en mode proxy (production)
    */
   static isUsingProxy(): boolean {
-    return import.meta.env.PROD;
+    return this.isProd();
   }
 
   /**

--- a/src/utils/webhookUrlHelper.ts
+++ b/src/utils/webhookUrlHelper.ts
@@ -7,8 +7,17 @@
  */
 
 import { configService } from '../services/configService';
+import { getCurrentSession, ensureOpenSession } from '../services/sessionService';
 
 export class WebhookUrlHelper {
+  private static isProd(): boolean {
+    try {
+      const meta = (import.meta as unknown as { env?: { PROD?: boolean } });
+      return Boolean(meta.env && meta.env.PROD);
+    } catch {
+      return false;
+    }
+  }
   /**
    * Retourne l'URL du webhook adaptée à l'environnement
    */
@@ -17,14 +26,14 @@ export class WebhookUrlHelper {
   ): string {
     // 🚀 UTILISER LE PROXY NETLIFY/VITE POUR ÉVITER CORS EN DÉVELOPPEMENT ET PRODUCTION
     console.log('🔍 WebhookUrlHelper - Environment check:', {
-      isProd: import.meta.env.PROD,
+      isProd: this.isProd(),
       hostname: window.location.hostname,
       willUseProxy:
-        import.meta.env.PROD || window.location.hostname === 'localhost',
+        this.isProd() || window.location.hostname === 'localhost',
     });
 
     // En production (Netlify) ET en développement local, utilise le proxy pour éviter CORS
-    if (import.meta.env.PROD || window.location.hostname === 'localhost') {
+    if (this.isProd() || window.location.hostname === 'localhost') {
       const proxyUrl = `/api/n8n/${endpoint}`;
       console.log('✅ Using proxy URL:', proxyUrl);
       return proxyUrl;
@@ -41,6 +50,44 @@ export class WebhookUrlHelper {
     // Sinon, construire l'URL complète
     const cleanBaseUrl = baseUrl.replace(/\/$/, ''); // Enlever le / final si présent
     return `${cleanBaseUrl}/${endpoint}`;
+  }
+
+  /**
+   * Ajoute des paramètres de requête à une URL (relative ou absolue)
+   */
+  static appendQueryParams(
+    url: string,
+    params: Record<string, string | number | boolean | undefined | null>
+  ): string {
+    try {
+      // Supporte les URLs relatives en utilisant l'origine courante
+      const base = url.startsWith('http')
+        ? new URL(url)
+        : new URL(url, window.location.origin);
+
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+          base.searchParams.set(key, String(value));
+        }
+      });
+
+      // Si l'URL initiale était relative, retourner un chemin relatif
+      if (!url.startsWith('http')) {
+        return base.pathname + (base.search ? base.search : '');
+      }
+      return base.toString();
+    } catch {
+      // En cas d'échec, retourner l'URL d'origine
+      return url;
+    }
+  }
+
+  /**
+   * Retourne un identifiant de session stable pour servir de clé (key)
+   */
+  static getSessionKey(): string {
+    const session = getCurrentSession() ?? ensureOpenSession().data ?? null;
+    return session?.id ?? 'anonymous';
   }
 
   /**
@@ -76,7 +123,7 @@ export class WebhookUrlHelper {
     directUrl: string;
   } {
     return {
-      environment: import.meta.env.PROD ? 'production' : 'development',
+      environment: this.isProd() ? 'production' : 'development',
       usingProxy: this.isUsingProxy(),
       webhookUrl: this.getWebhookUrl(),
       directUrl: this.getDirectUrl(),


### PR DESCRIPTION
Adds a stable session key to n8n webhook calls to resolve the "Key parameter is empty" error.

The n8n integration requires a `key` parameter for session identification. This PR ensures a stable session ID is generated and passed in both the URL query string and the request payload/form data for all n8n webhook calls, including those using the "Connected Chat Trigger Node" option. It also updates the Netlify proxy to correctly forward query parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc43c53c-742f-4a27-9005-9f9e2a0d0017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc43c53c-742f-4a27-9005-9f9e2a0d0017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

